### PR TITLE
Test Updates for [Autoscaling.5] Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses

### DIFF
--- a/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip.rego
+++ b/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip.rego
@@ -1,0 +1,41 @@
+package rules.autoscaling_no_public_ip
+
+import data.fugue
+
+__rego__metadoc__ := {
+    "id": "Autoscaling.5",
+    "title": "Auto Scaling launch configurations should not assign public IP addresses",
+    "description": "Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses to enhance network security and prevent direct internet exposure.",
+    "custom": {
+        "controls": {"AWS-Foundational-Security-Best-Practices_v1.0.0": ["AWS-Foundational-Security-Best-Practices_v1.0.0_Autoscaling.5"]},
+        "severity": "High"
+    }
+}
+
+resource_type := "MULTIPLE"
+
+# Get all launch configuration resources
+launch_configs = fugue.resources("aws_launch_configuration")
+
+# Function to check if public IP assignment is disabled
+is_public_ip_disabled(config) {
+    not config.associate_public_ip_address
+}
+
+is_public_ip_disabled(config) {
+    config.associate_public_ip_address == false
+}
+
+# Allow resources that don't assign public IPs
+policy[p] {
+    config := launch_configs[_]
+    is_public_ip_disabled(config)
+    p = fugue.allow_resource(config)
+}
+
+# Deny resources that assign public IPs
+policy[p] {
+    config := launch_configs[_]
+    not is_public_ip_disabled(config)
+    p = fugue.deny_resource_with_message(config, "Auto Scaling launch configuration should not assign public IP addresses to EC2 instances")
+}

--- a/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip_allow.tf
+++ b/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip_allow.tf
@@ -1,0 +1,33 @@
+# Configure AWS provider for passing test case
+provider "aws" {
+  alias  = "pass_aws"
+  region = "us-west-2"
+}
+
+# Create a compliant launch configuration that doesn't assign public IPs
+resource "aws_launch_configuration" "pass_config" {
+  provider = aws.pass_aws
+  name_prefix   = "pass-launch-config"
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  # Compliant: Explicitly disables public IP address assignment
+  associate_public_ip_address = false
+
+  security_groups = ["sg-12345678"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create an auto scaling group using the compliant launch configuration
+resource "aws_autoscaling_group" "pass_asg" {
+  provider = aws.pass_aws
+  name                = "pass-asg"
+  launch_configuration = aws_launch_configuration.pass_config.name
+  min_size            = 1
+  max_size            = 3
+  desired_capacity    = 1
+  vpc_zone_identifier = ["subnet-12345678"]
+}

--- a/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip_deny.tf
+++ b/github/workspace/default_rego_output_folder/rules.autoscaling_no_public_ip_deny.tf
@@ -1,0 +1,33 @@
+# Configure AWS provider for failing test case
+provider "aws" {
+  alias  = "fail_aws"
+  region = "us-west-2"
+}
+
+# Create a non-compliant launch configuration that assigns public IPs
+resource "aws_launch_configuration" "fail_config" {
+  provider = aws.fail_aws
+  name_prefix   = "fail-launch-config"
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  # Non-compliant: Explicitly assigns public IP addresses
+  associate_public_ip_address = true
+
+  security_groups = ["sg-12345678"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create an auto scaling group using the non-compliant launch configuration
+resource "aws_autoscaling_group" "fail_asg" {
+  provider = aws.fail_aws
+  name                = "fail-asg"
+  launch_configuration = aws_launch_configuration.fail_config.name
+  min_size            = 1
+  max_size            = 3
+  desired_capacity    = 1
+  vpc_zone_identifier = ["subnet-12345678"]
+}


### PR DESCRIPTION
Starchitect Generated tests for [Autoscaling.5] Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses.