### PR TITLE
Test Updates for [Autoscaling.5] Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses

### DIFF
--- a/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip.rego
+++ b/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip.rego
@@ -1,0 +1,44 @@
+package rules.autoscaling_launch_config_public_ip
+
+import data.fugue
+
+__rego__metadoc__ := {
+    "id": "Autoscaling.5",
+    "title": "Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses",
+    "description": "Auto Scaling group launch configurations must not assign public IP addresses to EC2 instances for enhanced security. Instances should only be accessible through load balancers and not directly exposed to the internet.",
+    "custom": {
+        "controls": {"AWS-Foundational-Security-Best-Practices_v1.0.0": ["AWS-Foundational-Security-Best-Practices_v1.0.0_Autoscaling.5"]},
+        "severity": "High"
+    }
+}
+
+resource_type := "MULTIPLE"
+
+# Get all launch configurations
+launch_configs = fugue.resources("aws_launch_configuration")
+
+# Helper function to check if public IP is disabled
+is_public_ip_disabled(config) {
+    config.associate_public_ip_address == false
+}
+
+is_public_ip_disabled(config) {
+    not config.associate_public_ip_address
+}
+
+# Allow configurations with public IP disabled
+policy[p] {
+    config := launch_configs[_]
+    is_public_ip_disabled(config)
+    p = fugue.allow_resource(config)
+}
+
+# Deny configurations with public IP enabled
+policy[p] {
+    config := launch_configs[_]
+    not is_public_ip_disabled(config)
+    p = fugue.deny_resource_with_message(
+        config,
+        "Launch configuration should not assign public IP addresses to EC2 instances"
+    )
+}

--- a/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip_allow.tf
+++ b/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip_allow.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  alias  = "pass_aws"
+  region = "us-west-2"
+}
+
+# Create a compliant launch configuration with public IP disabled
+resource "aws_launch_configuration" "pass_config" {
+  provider = aws.pass_aws
+  name_prefix = "pass-launch-config"
+  image_id = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+  
+  # Compliant: Explicitly disabling public IP
+  associate_public_ip_address = false
+  
+  security_groups = ["sg-12345678"]
+  
+  root_block_device {
+    volume_size = 8
+    volume_type = "gp2"
+    encrypted   = true
+  }
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create autoscaling group using the compliant launch configuration
+resource "aws_autoscaling_group" "pass_asg" {
+  provider = aws.pass_aws
+  name = "pass-asg"
+  max_size = 3
+  min_size = 1
+  desired_capacity = 1
+  launch_configuration = aws_launch_configuration.pass_config.name
+  vpc_zone_identifier = ["subnet-12345678"]
+  
+  tag {
+    key = "Environment"
+    value = "Production"
+    propagate_at_launch = true
+  }
+}

--- a/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip_deny.tf
+++ b/github/workspace/default_rego_output_folder/aws_autoscaling_launch_config_public_ip_deny.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  alias  = "fail_aws"
+  region = "us-west-2"
+}
+
+# Create a non-compliant launch configuration with public IP enabled
+resource "aws_launch_configuration" "fail_config" {
+  provider = aws.fail_aws
+  name_prefix = "fail-launch-config"
+  image_id = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+  
+  # Non-compliant: Explicitly enabling public IP
+  associate_public_ip_address = true
+  
+  security_groups = ["sg-12345678"]
+  
+  root_block_device {
+    volume_size = 8
+    volume_type = "gp2"
+  }
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Create autoscaling group using the non-compliant launch configuration
+resource "aws_autoscaling_group" "fail_asg" {
+  provider = aws.fail_aws
+  name = "fail-asg"
+  max_size = 3
+  min_size = 1
+  desired_capacity = 1
+  launch_configuration = aws_launch_configuration.fail_config.name
+  vpc_zone_identifier = ["subnet-12345678"]
+}


### PR DESCRIPTION
Starchitect Generated tests for [Autoscaling.5] Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses.
threadId: 1731302673406